### PR TITLE
Add filter to only find threatActors, and better name

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -260,9 +260,9 @@
       "objects": ["technique"]
     },
     {
-      "name": "tools",
+      "name": "threat actors via tools",
       "description": "Find threat actors that use tools that implement this technique.",
-      "query": "g.inE('implements').otherV().optional(emit().repeat(outE('alias').otherV()).until(cyclicPath())).inE('classifiedAs').otherV().outE('observedIn').otherV().repeat(outE('attributedTo').otherV()).times(2).optional(emit().repeat(outE('alias').otherV()).until(cyclicPath())).path().unfold()",
+      "query": "g.inE('implements').otherV().optional(emit().repeat(outE('alias').otherV()).until(cyclicPath())).inE('classifiedAs').otherV().outE('observedIn').otherV().repeat(outE('attributedTo').otherV()).times(2).hasLabel('threatActor').optional(emit().repeat(outE('alias').otherV()).until(cyclicPath())).path().unfold()",
       "objects": ["technique"]
     },
     {

--- a/src/config.json
+++ b/src/config.json
@@ -260,7 +260,7 @@
       "objects": ["technique"]
     },
     {
-      "name": "threat actors via tools",
+      "name": "tools",
       "description": "Find threat actors that use tools that implement this technique.",
       "query": "g.inE('implements').otherV().optional(emit().repeat(outE('alias').otherV()).until(cyclicPath())).inE('classifiedAs').otherV().outE('observedIn').otherV().repeat(outE('attributedTo').otherV()).times(2).hasLabel('threatActor').optional(emit().repeat(outE('alias').otherV()).until(cyclicPath())).path().unfold()",
       "objects": ["technique"]


### PR DESCRIPTION
Added a better name for the button (as it doesnt fint tools), and added a filter for it so it doesn't go through all campaigns, thus not using as much time and resources.